### PR TITLE
F2F-366: Added CODEOWNERS file to manage account access

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This is the CODEOWNERS file. These owners will be the default owners for everything in the di-ipv-cri-f2f-front repository
+# The following below will be requested for review when someone opens a pull request.
+
+* @alphagov/di-ipv-kiwi-front-codeowners


### PR DESCRIPTION
### What changed
Codeowners file added with relevant github team

[F2F-366](https://govukverify.atlassian.net/browse/F2F-366)