### PR TITLE
[F2F-476] Table name set with stack name in dev

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -633,7 +633,14 @@ Resources:
     Type: AWS::DynamoDB::Table
     Properties:
       # checkov:skip=CKV_AWS_28: Point in time recovery is not necessary for this table.
-      TableName: !Sub "f2f-front-sessions-${Environment}"
+      TableName: !If
+        - IsNotDevelopment
+        - !Sub
+          - "${SESSIONTABLENAME}"
+          - SESSIONTABLENAME: !FindInMap [EnvironmentVariables, !Ref Environment, SESSIONTABLENAME]
+        - !Sub
+          - "${SESSIONTABLENAME}-${AWS::StackName}"
+          - SESSIONTABLENAME: !FindInMap [EnvironmentVariables, !Ref Environment, SESSIONTABLENAME]
       BillingMode: "PAY_PER_REQUEST"
       AttributeDefinitions:
         - AttributeName: "id"
@@ -662,3 +669,6 @@ Outputs:
     Export:
       Name: !Sub "${AWS::StackName}-F2FFrontGatewayId"
     Value: !Ref ApiGwHttpEndpoint
+  F2FFrontSessionsTableName:
+    Description: Table name for the FE sessions table
+    Value: !Ref F2fFrontSessionsTable

--- a/template.yaml
+++ b/template.yaml
@@ -337,7 +337,7 @@ Resources:
             - Name: EXTERNAL_WEBSITE_HOST
               Value: !GetAtt ApiGwHttpEndpoint.ApiEndpoint
             - Name: SESSION_TABLE_NAME
-              Value: !FindInMap [EnvironmentVariables, !Ref Environment, SESSIONTABLENAME ]
+              Value: !Ref F2fFrontSessionsTable
             - Name: FRONT_END_URL
               Value: !Sub
                 - "https://${Url}"


### PR DESCRIPTION
## Proposed changes

### What changed

- Ensured the session table name is created based on the Env Var defined in the template
- For dev, the session table name also includes the AWS Stack Name
- Added an output to expose the name of the table actually deployed

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

- [F2F-476](https://govukverify.atlassian.net/browse/F2F-476)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations
<!-- Add any other consideration if needed -->

[F2F-476]: https://govukverify.atlassian.net/browse/F2F-476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ