### PR TITLE
F2F-445: Removed old root folder CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-di-ipv-kiwi-front-codeowners


### PR DESCRIPTION
### What changed

Removed old root folder CODEOWNERS file which was not  in use


### Issue tracking

- [F2F-445](https://govukverify.atlassian.net/browse/F2F-445)

## Checklists


[F2F-445]: https://govukverify.atlassian.net/browse/F2F-445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ