### PR TITLE
[F2F-589] - F2F UI - Critical/Serious Accessibility Violations

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -147,3 +147,8 @@ main p,
 #indedntedInstruction {
   margin-bottom: 2px;
 }
+
+#postcode-label {
+  font-weight: bold;
+  font-size: 24px;
+}

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -124,7 +124,7 @@ eeaIdCardExpiryDate:
     "required-year": "Enter the full expiry date"
 
 postcode:
-  label: ""
+  label: Enter a UK Postcode
   hint: "For example, SW1A 2AA"
   validation:
     default: "Enter a valid UK postcode"

--- a/src/views/f2f/findBranch.html
+++ b/src/views/f2f/findBranch.html
@@ -6,10 +6,9 @@
 {% from "hmpo-text/macro.njk" import hmpoText %}
 
 {% block mainContent %}
-<h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
+    <h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
         {{ translate("findBranch.title") }}
     </h1>
-    <p class="govuk-!-font-weight-bold"> {{ translate("findBranch.body") }} </p><br>
     
     {% call hmpoForm(ctx, {attributes: {onsubmit: 'window.disableFormSubmit()'} }) %}
 


### PR DESCRIPTION
## Proposed changes
https://govukverify.atlassian.net/browse/F2F-589

### What changed
Updated /findBranch page to use label for form field.

### Why did it change
Page previously failed WCAG 2.1 accessibility requirements for go-live - specifically a lacking label for the input form (this was present visually, but not configured appropriately).

Attached evidence of axe tests passing with 0 critical/serious issues and label visible in HTML code for page:

![Screenshot 2023-05-11 at 13 03 57](https://github.com/alphagov/di-ipv-cri-f2f-front/assets/118540036/0b3ce706-7b0f-4437-a266-6b856c27d0f2)

![Screenshot 2023-05-11 at 12 51 09](https://github.com/alphagov/di-ipv-cri-f2f-front/assets/118540036/534f9658-5de6-4568-ba93-14b49a4ca114)

