### PR TITLE
[F2F-677] - F2F UI - Country Selector Screens Critical/Serious Accessibility Violations

### DIFF
--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -137,14 +137,17 @@ eeaIdCardAddressCheck:
     required: "Select if your identity card has your current address on it"
 
 eeaIdentityCardCountrySelector:
+  label: "Select country"
   validation:
     equal: "Select the country your EEA national identity card is from"
 
 euDrivingLicenceCountrySelector:
+  label: "Select country"
   validation:
     equal: "Select the country your EU photocard driving licence is from"
 
 nonUkPassportCountrySelector:
+  label: "Select country"
   validation:
     equal: "Select the country your passport is from"
 

--- a/src/views/f2f/eeaIdentityCardCountrySelector.html
+++ b/src/views/f2f/eeaIdentityCardCountrySelector.html
@@ -24,9 +24,7 @@
     <div class="hint-with-margin">
     {{ hmpoSelect(ctx, {
         id: "eeaIdentityCardCountrySelector",
-        legend: {
-            classes: "govuk-label"
-        }
+        label: translate("fields.eeaIdentityCardCountrySelector.label")
     }) }}
   </div>
 

--- a/src/views/f2f/euDrivingLicenceCountrySelector.html
+++ b/src/views/f2f/euDrivingLicenceCountrySelector.html
@@ -24,9 +24,7 @@
     <div class="hint-with-margin">
     {{ hmpoSelect(ctx, {
         id: "euDrivingLicenceCountrySelector",
-        legend: {
-            classes: "govuk-label"
-        }
+        label: translate("fields.euDrivingLicenceCountrySelector.label")
     }) }}
   </div>
 

--- a/src/views/f2f/nonUkPassportCountrySelector.html
+++ b/src/views/f2f/nonUkPassportCountrySelector.html
@@ -25,9 +25,7 @@
     <div class="hint-with-margin">
     {{ hmpoSelect(ctx, {
         id: "nonUkPassportCountrySelector",
-        legend: {
-            classes: "govuk-label"
-        }
+        label: translate("fields.nonUkPassportCountrySelector.label")
     }) }}
   </div>
 


### PR DESCRIPTION
https://govukverify.atlassian.net/browse/F2F-677

### What changed
Added label to country select drop-down where it is present (EU DL, EU ID, Non-UK Passport)
Updated designs: https://www.figma.com/file/tK7chtvE4bSaWSmBU7zcLV/F2F-Flow---Screen-Iterations?type=design&node-id=6616-289062&t=l9C5diTPMMbprlqX-4

### Why did it change
A label is required as to meet accessibility requirements, screenshot attached:

![Screenshot 2023-06-07 at 17 02 15](https://github.com/alphagov/di-ipv-cri-f2f-front/assets/118540036/4445e92c-3f50-43f7-ae2b-561a2102b609)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
