### PR TITLE
[F2F-909] updates post office details sent to document selection endpoint

### DIFF
--- a/src/app/f2f/controllers/checkDetails.js
+++ b/src/app/f2f/controllers/checkDetails.js
@@ -15,6 +15,7 @@ class CheckDetailsController extends DateController {
       const payLoadDetails = req.form.values.payLoadValues
       let postOfficeAddress;
       let postOfficeName;
+      let postOfficeAddressWithoutPostCode;
       let postOfficePostcode;
       let postOfficeLatitude;
       let postOfficeLongitude;
@@ -22,6 +23,7 @@ class CheckDetailsController extends DateController {
         case "1": {
           postOfficeAddress = addressDetails[0].hint.text;
           postOfficeName = addressDetails[0].text;
+          postOfficeAddressWithoutPostCode = payLoadDetails.location0.addressWithoutPostCode;
           postOfficePostcode = payLoadDetails.location0.postcode
           postOfficeLatitude = payLoadDetails.location0.latitude
           postOfficeLongitude = payLoadDetails.location0.longitude
@@ -30,6 +32,7 @@ class CheckDetailsController extends DateController {
         case "2": {
           postOfficeAddress = addressDetails[1].hint.text;
           postOfficeName = addressDetails[1].text;
+          postOfficeAddressWithoutPostCode = payLoadDetails.location1.addressWithoutPostCode;
           postOfficePostcode = payLoadDetails.location1.postcode
           postOfficeLatitude = payLoadDetails.location1.latitude
           postOfficeLongitude = payLoadDetails.location1.longitude
@@ -38,6 +41,7 @@ class CheckDetailsController extends DateController {
         case "3": {
           postOfficeAddress = addressDetails[2].hint.text;
           postOfficeName = addressDetails[2].text;
+          postOfficeAddressWithoutPostCode = payLoadDetails.location2.addressWithoutPostCode;
           postOfficePostcode = payLoadDetails.location2.postcode
           postOfficeLatitude = payLoadDetails.location2.latitude
           postOfficeLongitude = payLoadDetails.location2.longitude
@@ -46,6 +50,7 @@ class CheckDetailsController extends DateController {
         case "4": {
           postOfficeAddress = addressDetails[3].hint.text;
           postOfficeName = addressDetails[3].text;
+          postOfficeAddressWithoutPostCode = payLoadDetails.location3.addressWithoutPostCode;
           postOfficePostcode = payLoadDetails.location3.postcode
           postOfficeLatitude = payLoadDetails.location3.latitude
           postOfficeLongitude = payLoadDetails.location3.longitude
@@ -54,13 +59,16 @@ class CheckDetailsController extends DateController {
         case "5": {
           postOfficeAddress = addressDetails[4].hint.text;
           postOfficeName = addressDetails[4].text;
+          postOfficeAddressWithoutPostCode = payLoadDetails.location4.addressWithoutPostCode;
           postOfficePostcode = payLoadDetails.location4.postcode
           postOfficeLatitude = payLoadDetails.location4.latitude
           postOfficeLongitude = payLoadDetails.location4.longitude
           break;
         }
       }
+      req.sessionModel.set("postOfficeName", postOfficeName);
       req.sessionModel.set("postOfficeAddress", postOfficeAddress);
+      req.sessionModel.set("postOfficeAddressWithoutPostCode", postOfficeAddressWithoutPostCode);
       req.sessionModel.set("postOfficePostcode", postOfficePostcode);
       req.sessionModel.set("postOfficeLatitude", postOfficeLatitude);
       req.sessionModel.set("postOfficeLongitude", postOfficeLongitude);
@@ -141,7 +149,8 @@ class CheckDetailsController extends DateController {
           "country_code": req.sessionModel.get("countryCode")
         },
         "post_office_selection": {
-          "address": req.sessionModel.get("postOfficeAddress"),
+          "address": req.sessionModel.get("postOfficeAddressWithoutPostCode"),
+          "name": req.sessionModel.get("postOfficeName"),
           "location": {
             "latitude": req.sessionModel.get("postOfficeLatitude"),
             "longitude": req.sessionModel.get("postOfficeLongitude"),
@@ -149,6 +158,7 @@ class CheckDetailsController extends DateController {
           "post_code": req.sessionModel.get("postOfficePostcode")
         }
       }
+
       await this.saveF2fData(req.axios, f2fData, req);
       callback();
     } catch (err) {

--- a/src/app/f2f/controllers/checkDetails.test.js
+++ b/src/app/f2f/controllers/checkDetails.test.js
@@ -94,7 +94,8 @@ describe("CheckDetails controller", () => {
             "country_code": req.sessionModel.get("countryCode")
           },
           "post_office_selection": {
-            "address": req.sessionModel.get("postOfficeAddress"),
+            "name": req.sessionModel.get("postOfficeName"),
+            "address": req.sessionModel.get("postOfficeAddressWithoutPostCode"),
             "location": {
               "latitude": req.sessionModel.get("postOfficeLatitude"),
               "longitude": req.sessionModel.get("postOfficeLongitude"),

--- a/src/app/f2f/controllers/results.js
+++ b/src/app/f2f/controllers/results.js
@@ -65,26 +65,31 @@ class PostcodeSearchController extends BaseController {
       //Additional values for /documentSelection payload
       locals.payLoadValues = {
         location0: {
+          addressWithoutPostCode: resp.data[0].address.address1 + ", " + resp.data[0].address.address4 + ", " + resp.data[0].address.address5,
           postcode: resp.data[0].address.postcode,
           latitude: resp.data[0].address.latitude,
           longitude: resp.data[0].address.longitude
         },
         location1: {
+          addressWithoutPostCode: resp.data[1].address.address1 + ", " + resp.data[1].address.address4 + ", " + resp.data[1].address.address5,
           postcode: resp.data[1].address.postcode,
           latitude: resp.data[1].address.latitude,
           longitude: resp.data[1].address.longitude
         },
         location2: {
+          addressWithoutPostCode: resp.data[2].address.address1 + ", " + resp.data[2].address.address4 + ", " + resp.data[2].address.address5,
           postcode: resp.data[2].address.postcode,
           latitude: resp.data[2].address.latitude,
           longitude: resp.data[2].address.longitude
         },
         location3: {
+          addressWithoutPostCode: resp.data[3].address.address1 + ", " + resp.data[3].address.address4 + ", " + resp.data[3].address.address5,
           postcode: resp.data[3].address.postcode,
           latitude: resp.data[3].address.latitude,
           longitude: resp.data[3].address.longitude
         },
         location4: {
+          addressWithoutPostCode: resp.data[4].address.address1 + ", " + resp.data[4].address.address4 + ", " + resp.data[4].address.address5,
           postcode: resp.data[4].address.postcode,
           latitude: resp.data[4].address.latitude,
           longitude: resp.data[4].address.longitude


### PR DESCRIPTION
## Proposed changes

### What changed

- Sending the name of the post office to the /documentSelection endpoint
- Trimming off the postcode from the post office address, as the post office is it's own field and does not need to be repeated

### Why did it change

Tweaks requested out of beta testing

### Screenshots

Request body being sent to  /documentSelection
<img width="475" alt="Screenshot 2023-07-05 at 6 37 04 pm" src="https://github.com/alphagov/di-ipv-cri-f2f-front/assets/40401118/1cc41502-f1a0-494a-9f7c-d82e060efe79">


### Issue tracking
- [F2F-909](https://govukverify.atlassian.net/browse/F2F-909)

## Checklists

### Other considerations
- API changes have been made in [backend PR](https://github.com/alphagov/di-ipv-cri-f2f-api/pull/147) 

[F2F-909]: https://govukverify.atlassian.net/browse/F2F-909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ