### PR TITLE
Added test container script with reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ deploy/.aws-sam/
 deploy/samconfig.toml
 wafv2/
 package-lock.json
+test/reports/f2f-reports/
+test/reports/cucumber_report.json

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,16 @@
+FROM amazonlinux:2
+
+RUN yum update -y && yum upgrade -y
+
+RUN curl -sL https://rpm.nodesource.com/setup_16.x | bash -
+RUN curl -sL https://dl.yarnpkg.com/rpm/yarn.repo -o /etc/yum.repos.d/yarn.repo
+
+RUN yum install -y nodejs awscli yarn git jq java-1.8.0-openjdk libappindicator-gtk3 liberation-fonts procps
+
+COPY . /app
+WORKDIR /app
+COPY run-tests.sh /
+RUN chmod +x /run-tests.sh
+RUN cd /app && yarn install
+
+ENTRYPOINT ["/run-tests.sh"]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "node": "16.*",
     "yarn": "1.22.*"
   },
-
   "scripts": {
     "start": "node src/app.js",
     "start:ci": "API_BASE_URL=http://localhost:8090 REDIS_SESSION_URL= NODE_ENV=development node src/app.js",
@@ -27,12 +26,13 @@
     "test:coverage": "nyc --reporter=lcov --reporter=text-summary yarn test",
     "test:watch": "mocha --watch",
     "mocks": "yarn run wiremock --verbose --port 8090 --root-dir test/mocks",
-    "test:browser": "wait-on tcp:8090 tcp:5030 && API_BASE_URL=http://127.0.0.1:8090 cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js --tags @browser",
+    "test:browser": "wait-on tcp:8090 tcp:5030 && API_BASE_URL=http://127.0.0.1:8090 cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags @browser",
     "test:browser:only": "wait-on tcp:8090 tcp:5030 && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js --tags @only",
-    "test:browser:ci": "npm-run-all -p -r start:ci mocks test:browser",
+    "test:browser:ci": "npm-run-all -p -r start:ci mocks test:browser; npm run test:browser:report",
     "test:browser:ci:only": "npm-run-all -p -r start:ci mocks test:browser:only",
     "test:browser1": "wait-on tcp:8090 tcp:5030 && API_BASE_URL=http://127.0.0.1:8090 cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js --tags @test",
     "test:browser:ci1": "npm-run-all -p -r start:ci mocks test:browser1",
+    "test:browser:report": "node ./test/utils/multiReportGenerator.js",
     "check-translation": "node node_modules/di-ipv-cri-common-express/scripts/checkTranslations.js"
   },
   "repository": {
@@ -56,6 +56,7 @@
     "husky": "8.0.3",
     "lint-staged": "13.2.3",
     "mocha": "10.2.0",
+    "multiple-cucumber-html-reporter": "^3.4.0",
     "nodemon": "2.0.22",
     "npm-run-all": "4.1.5",
     "nyc": "15.1.0",
@@ -90,7 +91,7 @@
     "hmpo-logger": "7.0.1",
     "jest": "^29.3.1",
     "jsonwebtoken": "9.0.0",
-    "nunjucks": "3.2.4",
-    "moment": "^2.29.4"
+    "moment": "^2.29.4",
+    "nunjucks": "3.2.4"
   }
 }

--- a/run-tests-locally.sh
+++ b/run-tests-locally.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -eu
+
+if [ $# -ge 1 ] && [ -n "$1" ]
+then
+    echo "Running test container against $1"
+
+    export SAM_STACK=$1 
+    export AWS_REGION="eu-west-2"
+    export TEST_REPORT_DIR="results"
+    export ENVIRONMENT="dev"
+    export DockerImageName="$SAM_STACK"_testcontainerimage
+
+    mkdir -p results # The directory on the host where the test results will be outputted.
+
+    aws cloudformation describe-stacks --stack-name "$SAM_STACK" --region "$AWS_REGION" --query 'Stacks[0].Outputs[].{key: OutputKey, value: OutputValue}' --output text > cf-output.txt
+    eval $(awk '{ printf("export CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt)
+    awk '{ printf("CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt > docker_vars.env
+    echo TEST_REPORT_DIR="$TEST_REPORT_DIR" >> docker_vars.env
+    echo TEST_REPORT_ABSOLUTE_DIR="$TEST_REPORT_DIR" >> docker_vars.env
+    echo TEST_ENVIRONMENT="$ENVIRONMENT" >> docker_vars.env
+    echo ENVIRONMENT="$ENVIRONMENT" >> docker_vars.env
+    echo SAM_STACK_NAME="$SAM_STACK" >> docker_vars.env
+
+    #clean existing container and image before creating a new one
+    echo "Removing existing containers and images for the test"
+    docker ps -a --filter "ancestor=$DockerImageName" --filter "status=exited" -q | xargs docker rm
+    docker images $DockerImageName -q |xargs docker rmi
+
+    docker build -f Dockerfile.test -t $DockerImageName .
+    docker run --rm --env-file docker_vars.env -v $(pwd)/app/results:/results $DockerImageName
+else    
+    echo "Please ensure you've got a stack name as the first argument after ./run_tests_locally.sh..."
+    echo "E.g. ./run_tests_locally.sh f2f-cri-front"
+fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# The CFN variables seem to include quotes when used in tests these quotes must 
+# be removed before assigning these variable.
+remove_quotes () {
+  echo "$1" | tr -d '"'
+}
+
+# Github actions set to true for tests to run in headless mode
+export GITHUB_ACTIONS=true
+# shellcheck disable=SC2154
+export IPV_STUB_URL=$(remove_quotes $CFN_CICIPVStubExecuteURL)start
+
+cd /app; yarn run test:browser:ci
+
+cp -rf /app/test/reports $TEST_REPORT_ABSOLUTE_DIR

--- a/template.yaml
+++ b/template.yaml
@@ -43,6 +43,10 @@ Parameters:
     Type: Number
     Default: 0
     Description: Set to 1 to enable deployment of scaling infra in dev
+  IPVStubStackName:
+    Type: String
+    Default: "f2f-ipv-stub"
+    Description: The name of the deployed IPV stub stack.
 
 Conditions:
   IsNotDevelopment: !Or
@@ -51,6 +55,12 @@ Conditions:
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
   IsProduction: !Equals [ !Ref Environment, production ]
+  IsProdLikeEnvironment: !Or
+    - !Equals [!Ref Environment, staging]
+    - !Equals [!Ref Environment, integration]
+    - !Equals [!Ref Environment, production]
+  IsNotProdLikeEnvironment: !Not
+    - !Condition IsProdLikeEnvironment
   UsePermissionsBoundary:
     Fn::Not:
       - Fn::Equals:
@@ -1089,3 +1099,8 @@ Outputs:
   F2FCustomDomain:
     Description: F2F Custom Domain API Gateway ID
     Value: !Ref F2FFrontCustomDomain
+  F2FIPVStubExecuteURL:
+    Condition: IsNotProdLikeEnvironment
+    Description: "F2F IPV Stub"
+    Value:
+      Fn::ImportValue: !Sub '${IPVStubStackName}-IPVStubExecuteUrl'

--- a/test/utils/multiReportGenerator.js
+++ b/test/utils/multiReportGenerator.js
@@ -1,0 +1,31 @@
+const reporter = require("multiple-cucumber-html-reporter");
+var date = new Date();
+var currentDate = date.getDate() + '_' +( date.getMonth()+1) + '_' + date.getFullYear() + '_' + date.getHours() + '_' + date.getMinutes() + '_' + date.getSeconds() + '_' + date.getMilliseconds();
+
+var options = {
+    jsonDir: 'test/reports',
+    reportPath: 'test/reports/f2f-reports/cri-f2f-report_'+currentDate + '.html',
+    metadata: {
+        browser: {
+          name: "chrome",
+          version: "112.0.56",
+        },
+        device: "MacBook",
+        platform: {
+          name: "osx",
+          version: "Ventura 13.3.1",
+        },
+      },
+    disableLog: 'true',
+    openReportInBrowser: 'true',
+    customData: {
+        title: "Run info",
+        data: [
+          { label: "Project:", value: "Digital Identity: Face to Face" },
+          { label: "Release:", value: "June 2023" },
+          { label: "Environment:", value: "Local" },
+          { label: "Execution Start Time: ", value: (new Date()).toString().substring(0,25)},
+        ],
+      },
+};
+reporter.generate(options);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2072,6 +2072,11 @@ defer-to-connect@^2.0.0:
   resolved "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz"
   integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
 
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
 define-properties@^1.1.3, define-properties@^1.1.4:
   version "1.2.0"
   resolved "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz"
@@ -2691,6 +2696,13 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/find/-/find-0.3.0.tgz#4082e8fc8d8320f1a382b5e4f521b9bc50775cb8"
+  integrity sha512-iSd+O4OEYV/I36Zl8MdYJO0xD82wH528SaCieTVHhclgiYNe9y+yPKSwK+A7/WsmHL1EZ+pYUJBXWTL5qofksw==
+  dependencies:
+    traverse-chain "~0.1.0"
+
 findup@^0.1.5:
   version "0.1.5"
   resolved "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz"
@@ -2773,6 +2785,15 @@ fromentries@^1.2.0:
   version "1.3.2"
   resolved "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz"
   integrity sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==
+
+fs-extra@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
+  integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2977,6 +2998,11 @@ graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.9:
   version "4.2.10"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
 graphemer@^1.4.0:
   version "1.4.0"
@@ -3396,6 +3422,11 @@ is-date-object@^1.0.1:
   dependencies:
     has-tostringtag "^1.0.0"
 
+is-docker@^2.0.0, is-docker@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
@@ -3541,6 +3572,13 @@ is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+is-wsl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -4076,6 +4114,15 @@ json5@^2.2.2, json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
+jsonfile@^6.0.1, jsonfile@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonwebtoken@9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz#d0faf9ba1cc3a56255fe49c0961a67e520c1926d"
@@ -4325,6 +4372,11 @@ luxon@3.2.1:
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.2.1.tgz#14f1af209188ad61212578ea7e3d518d18cee45f"
   integrity sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==
 
+luxon@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.3.0.tgz#d73ab5b5d2b49a461c47cedbc7e73309b4805b48"
+  integrity sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==
+
 make-dir@^3.0.0, make-dir@^3.0.2:
   version "3.1.0"
   resolved "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz"
@@ -4508,6 +4560,19 @@ ms@2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+multiple-cucumber-html-reporter@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/multiple-cucumber-html-reporter/-/multiple-cucumber-html-reporter-3.4.0.tgz#03db1772834952c70555ee16074d26c308d18ca4"
+  integrity sha512-Y2FQA/OosmlsB/ZQUPJvnkKKYFKa/J+Qv2QUl5PsO3BC77jXwyPE8fAWopLH+CEYlRTs7fcdfydmWFitGMFi0A==
+  dependencies:
+    find "^0.3.0"
+    fs-extra "^11.1.1"
+    jsonfile "^6.1.0"
+    lodash "^4.17.21"
+    luxon "^3.3.0"
+    open "^8.4.2"
+    uuid "^9.0.0"
 
 mz@^2.7.0:
   version "2.7.0"
@@ -4786,6 +4851,15 @@ onetime@^6.0.0:
   integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
   dependencies:
     mimic-fn "^4.0.0"
+
+open@^8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
+  integrity sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
 
 optionator@^0.9.1:
   version "0.9.1"
@@ -5991,6 +6065,11 @@ touch@^3.1.0:
   dependencies:
     nopt "~1.0.10"
 
+traverse-chain@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/traverse-chain/-/traverse-chain-0.1.0.tgz#61dbc2d53b69ff6091a12a168fd7d433107e40f1"
+  integrity sha512-up6Yvai4PYKhpNp5PkYtx50m3KbwQrqDwbuZP/ItyL64YEWHAvH6Md83LFLV/GRSk/BoUVwwgUzX6SOQSbsfAg==
+
 tslib@^2.0.3, tslib@^2.1.0:
   version "2.5.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz"
@@ -6088,6 +6167,11 @@ underscore@^1.13.6:
   version "1.13.6"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### What changed

- Added test container shell script to run test in codepipeline and locally.
- Update template to include an output for F2F IPV stub URL.
- Docker.test file for the test container image.
- multiple-cucumber-html-reporter node module for html reports.

### Why did it change

Test container image required for running tests in the pipeline.

### Issue tracking
- [F2F-968](https://govukverify.atlassian.net/browse/F2F-968)

## Checklists

### Environment variables or secrets

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
<img width="589" alt="Screenshot 2023-07-23 at 15 12 58" src="https://github.com/alphagov/di-ipv-cri-f2f-front/assets/133013208/694a70ee-b48c-4c08-90e3-dc378f398231">

<img width="587" alt="Screenshot 2023-07-23 at 15 12 49" src="https://github.com/alphagov/di-ipv-cri-f2f-front/assets/133013208/e8b0cf26-3b7e-4d4c-bed4-c73380d02643">



[F2F-968]: https://govukverify.atlassian.net/browse/F2F-968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ