### PR TITLE
F2F-1131 increase cucumber timeout

### DIFF
--- a/test/browser/support/setup.js
+++ b/test/browser/support/setup.js
@@ -1,6 +1,9 @@
 const { Before, BeforeAll, AfterAll, After } = require("@cucumber/cucumber");
 const { chromium } = require("playwright");
+const { setDefaultTimeout } = require ('@cucumber/cucumber');
 const axios = require("axios");
+
+setDefaultTimeout(10 * 1000);
 
 BeforeAll(async function () {
   // Browsers are expensive in Playwright so only create 1


### PR DESCRIPTION
## Proposed changes

### What changed

The global timeout for steps in the cucumber tests is increased from 5s to 10s.

### Why did it change

Tests were timing out in the CodeBuild containers, whereas they passed on dev machines and on GHA.

### Issue tracking

- [F2F-1131](https://govukverify.atlassian.net/browse/F2F-1131)

[F2F-1131]: https://govukverify.atlassian.net/browse/F2F-1131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ