### PR TITLE
[F2F-1155] - Update expiryDate in FE test

### DIFF
--- a/test/browser/pages/ukPassportDetailsPageInvalidPast.js
+++ b/test/browser/pages/ukPassportDetailsPageInvalidPast.js
@@ -25,7 +25,7 @@ module.exports = class PlaywrightDevPage {
     const lowerUTC = new Date(
       new Date().getFullYear(),
       new Date().getMonth() - 18,
-      new Date().getDate() - 2
+      new Date().getDate() - 5
     )
       .toISOString();
     const fullDate = lowerUTC.split("T")[0]


### PR DESCRIPTION
### What changed

Extended the expiryDate calculation from 18months & 2 days to 18months and 5 days to account for leap years across the 18month period

### Issue tracking
https://govukverify.atlassian.net/browse/F2F-1155