### PR TITLE
[F2F-891] Updates dockerfile.test to use ubuntu

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,11 +1,18 @@
-FROM amazonlinux:2
+FROM ubuntu:latest
 
-RUN yum update -y && yum upgrade -y
+RUN apt update -y && apt upgrade -y
+RUN apt install -y curl unzip
 
-RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash -
-RUN curl -sL https://dl.yarnpkg.com/rpm/yarn.repo -o /etc/yum.repos.d/yarn.repo
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update -qq && apt-get install -y yarn nodejs
 
-RUN yum install -y nodejs awscli yarn git jq java-1.8.0-openjdk libappindicator-gtk3 liberation-fonts procps
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install
+
+RUN apt install -y git jq openjdk-8-jdk fonts-liberation libappindicator1 procps libxkbcommon0 libgbm1
 
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
### What changed

Updates dockerfile.test to use ubuntu

### Why did it change

amazonlinux is incompatible with node 18

### Screenshots

Dev deploy working 
<img width="1128" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-front/assets/40401118/67e5eb73-17fd-4a26-bbde-23cc8f30d701">

### Issue tracking
- [F2F-891](https://govukverify.atlassian.net/browse/F2F-891)


[F2F-891]: https://govukverify.atlassian.net/browse/F2F-891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ