### PR TITLE
[KIWI-1245] Decode the redirect URL on Abort

### DIFF
--- a/src/app/f2f/controllers/abort.js
+++ b/src/app/f2f/controllers/abort.js
@@ -25,7 +25,7 @@ class AbortController extends BaseController {
 		);
 
 		if (response.status === 200 && response.headers.location) {
-      const REDIRECT_URL = response.headers.location;
+      const REDIRECT_URL = decodeURIComponent(response.headers.location);
 			res.redirect(REDIRECT_URL)
     }
 	}


### PR DESCRIPTION
### What changed

Currently the redirect URL appears like so id=f2f?error%3Daccess_denied&
This change adds decodeURIComponent to decode the encoded URL from Abort endpoint

<img width="1728" alt="image" src="https://github.com/alphagov/di-ipv-cri-f2f-front/assets/13416125/1a7ea9a2-4559-4d30-b817-4c56461cd58f">

