### PR TITLE
[KIWI-2329] - F2F | FE | Remove text fields relating to footer and banners

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -10,52 +10,6 @@ govuk:
   error: Gwall
   warning: Rhybudd
   skipLink: Neidio i'r prif gynnwys
-  cookie:
-    cookieBanner:
-      title: "Cwcis ar GOV.UK One Login"
-      heading: "Cwcis ar GOV.UK One Login"
-      paragraph1: "Rydym yn defnyddio rhai cwcis hanfodol i wneud i'r gwasanaeth hwn weithio."
-      paragraph2: "Hoffem osod cwcis ychwanegol er mwyn i ni allu cofio eich gosodiadau, deall sut mae pobl yn defnyddio'r gwasanaeth a gwneud gwelliannau."
-      buttonAcceptText: "Derbyn cwcis dadansoddi"
-      buttonRejectText: "Gwrthod cwcis dadansoddi"
-      linkViewCookiesText: "Gweld cwcis"
-      cookieBannerHideLink: "Cuddio'r neges yma"
-      cookieBannerAccept:
-        paragraph1: "Rydych wedi derbyn cwcis ychwanegol. Gallwch "
-        paragraph2: " unrhyw bryd."
-      cookieBannerReject:
-        paragraph1: "Rydych wedi gwrthod cwcis ychwanegol. Gallwch "
-        paragraph2: " unrhyw bryd."
-      changeCookiePreferencesLink: "newid eich gosodiadau cwcis"
-    cookieText: "Mae GOV.UK yn defnyddio cwcis i wneud y safle'n symlach."
-    cookieLink: "#"
-    cookieLinkText: "Darganfyddwch fwy am gwcis"
-  phaseBanner:
-    tag: beta
-    content: Mae hwn yn wasanaeth newydd – bydd eich <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-o.account.gov.uk/prove-identity-post-office" class="govuk-link" rel="noopener" target="_blank">adborth (agor mewn tab newydd)</a> yn ein helpu i'w wella.
-  languageToggle:
-    ariaLabel: Dewis iaith
-    englishLanguage: English
-    welshLanguage: Cymraeg
-    englishVisuallyHidden: Change to English
-    welshVisuallyHidden: Newid yr iaith ir Gymraeg
-  footerNavItems:
-    meta:
-      items:
-        - href: https://signin.account.gov.uk/accessibility-statement
-          text: Datganiad hygyrchedd
-        - href: https://signin.account.gov.uk/cookies
-          text: Cwcis
-        - href: https://signin.account.gov.uk/terms-and-conditions
-          text: Telerau ac amodau
-        - href: https://signin.account.gov.uk/privacy-notice
-          text: Hysbysiad preifatrwydd
-        - href: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-o.account.gov.uk/prove-identity-post-office
-          text: Cymorth
-  copyright:
-    text: "© Hawlfraint y Goron"
-  contentLicence:
-    html: Mae'r holl gynnwys ar gael o dan <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="licence">Drwydded Llywodraeth Agored v3.0</a>, ac eithrio lle nodir yn wahanol
 
 error:
   unrecoverable:

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -10,52 +10,6 @@ govuk:
   error: Error
   warning: Warning
   skipLink: Skip to main content
-  cookie:
-    cookieBanner:
-      title: "Cookies on GOV.UK One Login"
-      heading: "Cookies on GOV.UK One Login"
-      paragraph1: "We use some essential cookies to make this service work."
-      paragraph2: "We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements."
-      buttonAcceptText: "Accept analytics cookies"
-      buttonRejectText: "Reject analytics cookies"
-      linkViewCookiesText: "View cookies"
-      cookieBannerHideLink: "Hide this message"
-      cookieBannerAccept:
-        paragraph1: "You’ve accepted additional cookies. You can "
-        paragraph2: " at any time."
-      cookieBannerReject:
-        paragraph1: "You’ve rejected additional cookies. You can "
-        paragraph2: " at any time."
-      changeCookiePreferencesLink: "change your cookie settings"
-    cookieText: "GOV.UK uses cookies to make the site simpler."
-    cookieLink: "#"
-    cookieLinkText: "Find out more about cookies"
-  phaseBanner:
-    tag: beta
-    content: This is a new service – your <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-o.account.gov.uk/prove-identity-post-office" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
-  languageToggle:
-    ariaLabel: Choose Language
-    englishLanguage: English
-    welshLanguage: Cymraeg
-    englishVisuallyHidden: Change to English
-    welshVisuallyHidden: Newid yr iaith ir Gymraeg
-  footerNavItems:
-    meta:
-      items:
-        - href: https://signin.account.gov.uk/accessibility-statement
-          text: Accessibility statement
-        - href: https://signin.account.gov.uk/cookies
-          text: Cookies
-        - href: https://signin.account.gov.uk/terms-and-conditions
-          text: Terms and conditions
-        - href: https://signin.account.gov.uk/privacy-notice
-          text: Privacy notice
-        - href: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-o.account.gov.uk/prove-identity-post-office
-          text: Support
-  copyright:
-    text: "© Crown copyright"
-  contentLicence:
-    html: "All content is available under the <a class=\"govuk-footer__link\" href=\"https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\" rel=\"licence\">Open Government Licence v3.0</a>, except where otherwise stated"
 
 error:
   unrecoverable:


### PR DESCRIPTION
## Proposed changes

### What changed

Remove text fields relating to rebranding in `default.yml` for both languages

### Why did it change

The common-express, which introduces the brand changes holds the default fields for govuk text in both languages, the change is to prevent any risk of overriding or misalignment in the future.

### Issue tracking

- [KIWI-2329](https://govukverify.atlassian.net/browse/KIWI-2329)

### English page
<img width="378" height="565" alt="Screenshot 2025-08-01 at 14 20 30" src="https://github.com/user-attachments/assets/18550b1f-0adf-458a-bd11-7e7177222a91" />

### Welsh  page
<img width="410" height="588" alt="Screenshot 2025-08-01 at 14 20 39" src="https://github.com/user-attachments/assets/3e184681-d2ea-43f4-aa62-4bf38b0e075a" />

[KIWI-2329]: https://govukverify.atlassian.net/browse/KIWI-2329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ