### PR TITLE
feat(DFC-1226): Remove content ID from error page

### DIFF
--- a/src/views/errors/error.html
+++ b/src/views/errors/error.html
@@ -4,7 +4,6 @@
 
 {% set hmpoPageKey = "error.unrecoverable" %}
 
-{% set contentID = "3e8b784d-6c7e-4ca2-a39d-da2c2290a147" %}
 {% set isPageDataSensitive = false %}
 {% set taxLevel2 = "f2f" %}
 {% set statusCode = "500" %}


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

Removes GA content ID for the error page. This is so content ID will be determined by the page that had the error, rather than the error page itself.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DFC-1226](https://govukverify.atlassian.net/browse/DFC-1226)

[DFC-1226]: https://govukverify.atlassian.net/browse/DFC-1226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ